### PR TITLE
fix: configure Edge Runtime for deployment

### DIFF
--- a/app/auth/callback/route.ts
+++ b/app/auth/callback/route.ts
@@ -1,6 +1,8 @@
 import { createClient } from "@/lib/supabase/server"
 import { type NextRequest, NextResponse } from "next/server"
 
+export const runtime = "edge"
+
 export async function GET(request: NextRequest) {
   const { searchParams, origin } = new URL(request.url)
   const code = searchParams.get("code")

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,6 +1,8 @@
 import { createServerClient } from "@supabase/ssr"
 import { NextResponse, type NextRequest } from "next/server"
 
+export const runtime = "edge"
+
 export async function middleware(request: NextRequest) {
   let supabaseResponse = NextResponse.next({
     request,

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,5 +1,14 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  experimental: {
+    serverComponentsExternalPackages: ['@supabase/ssr'],
+  },
+  webpack: (config, { isServer }) => {
+    if (isServer) {
+      config.externals.push('@supabase/ssr')
+    }
+    return config
+  },
   eslint: {
     ignoreDuringBuilds: true,
   },


### PR DESCRIPTION
Add runtime configuration to prevent `__dirname` errors.

#VERCEL_SKIP